### PR TITLE
Stop hardcoding python2.6.

### DIFF
--- a/Makefile.deps
+++ b/Makefile.deps
@@ -12,7 +12,7 @@
 # javascriptlint
 #
 JSL_SCRIPT	= deps/javascriptlint/build/install/jsl
-JSL		= python2.6 $(JSL_SCRIPT)
+JSL		= python $(JSL_SCRIPT)
 
 $(JSL_SCRIPT): | deps/javascriptlint/.git
 	cd deps/javascriptlint && make install


### PR DESCRIPTION
You may also want to update the submodules.  I had to get davepacheco/javascriptlint@e1bd0abfd424811af469d1ece3af131d95443924 to compile cleanly on Ubuntu 12.04 and 13.04.

\- Dimitri
