### PR TITLE
Updated package.redis.json deps for node v0.12.x

### DIFF
--- a/package-redis.json
+++ b/package-redis.json
@@ -16,8 +16,8 @@
     "wf": "~0.10",
     "wf-redis-backend": "~0.10",
     "bunyan": "0.23.1",
-    "restify": "2.6.1",
-    "node-uuid": "1.4.0",
+    "restify": "2.8.5",
+    "node-uuid": "1.4.2",
     "pooling": "0.4.6"
   },
   "devDependencies": {}


### PR DESCRIPTION
Bumped restify to 2.8.5 from 2.6.1 and node-uuid from 1.4.0 to 1.4.2

These are the minimal required changes.