### PR TITLE
Make timing.js pass linting checks

### DIFF
--- a/timing.js
+++ b/timing.js
@@ -8,39 +8,37 @@ var $login = process.argv[2];
 var $password = process.argv[3];
 
 var exec = require('child_process').exec;
-var scripts = [{name: 'api.js'}, {name:'module.js'}, {name:'node.js'}];
+var scripts = [ {name: 'api.js'}, {name:'module.js'}, {name:'node.js'} ];
 
 var i = 0, current = 0;
 
-scripts.forEach(function(script) {
-	script.exec = function() {
-		script.start = {
-			'date': new Date(),
-			'hrtime': process.hrtime()
-		}
-		var child = exec('node ./' + script.name + ' ' + $login + ' ' + $password);
-//		child.stdout.on('data', console.log);
-		child.stderr.on('data', console.error);
-		child.on('close', function() {
-			script.end = {
-				'date': new Date() - script.start.date,
-				'hrtime': process.hrtime(script.start.hrtime)
-			}
-			current++;
-			if (current == scripts.length)
-				fin();
-			else
-				scripts[current].exec();
-		});
-	};
-	if (++i == scripts.length)
-		scripts[current].exec();
+scripts.forEach(function (script) {
+  script.exec = function () {
+    script.start = {
+      'date': new Date(),
+      'hrtime': process.hrtime()
+    };
+    var child = exec('node ./' + script.name + ' ' + $login + ' ' + $password);
+//    child.stdout.on('data', console.log);
+    child.stderr.on('data', console.error);
+    child.on('close', function () {
+      script.end = {
+        'date': new Date() - script.start.date,
+        'hrtime': process.hrtime(script.start.hrtime)
+      };
+      current++;
+      if (current == scripts.length)
+        fin();
+      else
+        scripts[current].exec();
+    });
+  };
+  if (++i == scripts.length)
+    scripts[current].exec();
 });
 
 function fin() {
-	scripts.forEach(function(script) {
- 		console.info("(%s)\tExecution time:\t%dms", script.name, script.end.date);
-//		console.info("(%s)\tExecution time (hr):\t%dms", script.name, (script.end.hrtime[0]*1000) + (script.end.hrtime[1]/1000000));
-	});
-};
-
+  scripts.forEach(function (script) {
+     console.info('(%s) Execution time: %dms', script.name, script.end.date);
+  });
+}


### PR DESCRIPTION
`jsl` issues:

```
src/node-workflow-example/timing.js(20): warning: missing semicolon
src/node-workflow-example/timing.js(28): warning: missing semicolon
src/node-workflow-example/timing.js(45): warning: empty statement or extra semicolon
```

`jsstyle` issues:

```
timing.js: 15: missing space between 'function' and paren
timing.js: 16: indent by tabs instead of spaces
timing.js: 16: missing space between 'function' and paren
timing.js: 17: indent by tabs instead of spaces
timing.js: 18: indent by tabs instead of spaces
timing.js: 19: indent by tabs instead of spaces
timing.js: 20: indent by tabs instead of spaces
timing.js: 21: line > 80 characters
timing.js: 21: indent by tabs instead of spaces
timing.js: 23: indent by tabs instead of spaces
timing.js: 24: indent by tabs instead of spaces
timing.js: 24: missing space between 'function' and paren
timing.js: 25: indent by tabs instead of spaces
timing.js: 26: indent by tabs instead of spaces
timing.js: 27: indent by tabs instead of spaces
timing.js: 28: indent by tabs instead of spaces
timing.js: 29: indent by tabs instead of spaces
timing.js: 30: indent by tabs instead of spaces
timing.js: 31: indent by tabs instead of spaces
timing.js: 32: indent by tabs instead of spaces
timing.js: 33: indent by tabs instead of spaces
timing.js: 34: indent by tabs instead of spaces
timing.js: 35: indent by tabs instead of spaces
timing.js: 36: indent by tabs instead of spaces
timing.js: 37: indent by tabs instead of spaces
timing.js: 41: indent by tabs instead of spaces
timing.js: 41: missing space between 'function' and paren
timing.js: 42: line > 80 characters
timing.js: 42: indent of 1 space(s) instead of 2
timing.js: 42: literal string using double-quote instead of single
timing.js: 43: line > 80 characters
timing.js: 44: indent by tabs instead of spaces
timing.js: 46: last line in file is blank
```
